### PR TITLE
Fix deploy script and add Gradio web UI

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,8 @@ Please refer to [INSTALL.md](INSTALL.md) for general instructions on environment
 
 You can also run `bash scripts/deploy_pipeline.sh` for a quick deployment that installs
 all requirements, authenticates with Hugging Face, and displays the available models.
+For an interactive experience, launch `bash scripts/deployment_webui.sh` which provides
+a Gradio interface to select and run the included use cases.
 
 ### Inference with pre-trained Cosmos-Predict1 models
 * [Inference with diffusion-based Text2World models](/examples/inference_diffusion_text2world.md) **[with multi-GPU support]**

--- a/scripts/deploy_pipeline.sh
+++ b/scripts/deploy_pipeline.sh
@@ -27,9 +27,11 @@ echo "\nInstalling dependencies..."
 python3 -m pip install --upgrade pip
 python3 -m pip install -r requirements.txt
 python3 -m pip install --upgrade torch torchvision
+python3 -m pip install -e .
+python3 -m pip install gradio
 
 # Login to Hugging Face after installing huggingface-hub
-huggingface-cli login --token "$HF_KEY" --non-interactive
+huggingface-cli login --token "$HF_KEY"
 
 echo "\nAvailable Cosmos-Predict1 models:\n"
 grep "\* \[Cosmos" README.md | sed 's/^* //'

--- a/scripts/deployment_webui.py
+++ b/scripts/deployment_webui.py
@@ -1,0 +1,103 @@
+#!/usr/bin/env python3
+"""Simple Gradio launcher for Cosmos-Predict1 pipelines."""
+
+import os
+import re
+import socket
+import subprocess
+from pathlib import Path
+from typing import Dict, List
+
+import gradio as gr
+
+
+def _read_models() -> List[str]:
+    """Parse README.md and return a list of available models."""
+    models = []
+    collect = False
+    for line in Path("README.md").read_text().splitlines():
+        if line.strip() == "## Cosmos-Predict1 Models":
+            collect = True
+            continue
+        if collect:
+            if line.startswith("* [Cosmos"):
+                models.append(line.strip().lstrip("* "))
+            elif line.strip() == "":
+                if models:
+                    break
+    return models
+
+
+def _parse_example_scripts() -> Dict[str, str]:
+    """Return a mapping from use case name to script path."""
+    mapping = {}
+    examples_dir = Path("examples")
+    pattern_py = re.compile(r"python\s+(cosmos_predict1/[\w/]+\.py)")
+    pattern_m = re.compile(r"-m\s+(cosmos_predict1[\w\.]+)")
+
+    for md in sorted(examples_dir.glob("*.md")):
+        name = md.stem.replace("_", " ")
+        script = None
+        for line in md.read_text().splitlines():
+            m = pattern_py.search(line)
+            if m:
+                script = m.group(1)
+                break
+            m = pattern_m.search(line)
+            if m:
+                script = m.group(1)
+                if not script.endswith(".py"):
+                    script = script.replace(".", "/") + ".py"
+                break
+        mapping[name] = script
+    return mapping
+
+
+def _get_free_port(start: int = 7860) -> int:
+    port = start
+    while True:
+        with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
+            if s.connect_ex(("127.0.0.1", port)) != 0:
+                return port
+        port += 1
+
+
+USE_CASES = _parse_example_scripts()
+MODELS = _read_models()
+
+
+def launch_use_case(use_case: str) -> str:
+    script = USE_CASES.get(use_case)
+    if not script:
+        return f"No script found for '{use_case}'."
+
+    port = _get_free_port()
+    env = os.environ.copy()
+    env.setdefault("GRADIO_SERVER_PORT", str(port))
+
+    if script.endswith(".py"):
+        cmd = ["python3", script]
+    else:
+        cmd = ["python3", "-m", script]
+
+    subprocess.Popen(cmd, env=env)
+    return f"Started {script} on port {port}."
+
+
+def main() -> None:
+    with gr.Blocks() as demo:
+        gr.Markdown("# Cosmos-Predict1 Deployment")
+        gr.Markdown("## Available Models")
+        gr.Markdown("\n".join(MODELS))
+
+        gr.Markdown("## Use Cases")
+        use_case_dd = gr.Dropdown(choices=list(USE_CASES.keys()), label="Select Use Case")
+        out = gr.Textbox(label="Status")
+        gr.Button("Launch").click(fn=launch_use_case, inputs=use_case_dd, outputs=out)
+
+    demo.launch()
+
+
+if __name__ == "__main__":
+    main()
+

--- a/scripts/deployment_webui.sh
+++ b/scripts/deployment_webui.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+set -e
+
+repo_root=$(git rev-parse --show-toplevel)
+cd "$repo_root"
+
+python3 scripts/deployment_webui.py "$@"
+


### PR DESCRIPTION
## Summary
- update `deploy_pipeline.sh` to remove unsupported `--non-interactive` flag
- install the repo and gradio when deploying
- create a Gradio based webUI launcher `deployment_webui.py`
- provide wrapper script `deployment_webui.sh`
- mention new web UI in README

## Testing
- `python3 scripts/test_environment.py` *(fails: Package not successfully imported: torch)*

------
https://chatgpt.com/codex/tasks/task_e_686fd2b31074832abda5abd758bb4501