### PR TITLE
Use conda in deployment script

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,8 @@ We provide a comphrehensive set of examples to illustrate how to perform inferen
 Please refer to [INSTALL.md](INSTALL.md) for general instructions on environment setup.
 
 You can also run `bash scripts/deploy_pipeline.sh` for a quick deployment that installs
-all requirements, authenticates with Hugging Face, and displays the available models.
+all requirements in a `cosmos-predict1` conda environment, authenticates with Hugging Face,
+and displays the available models.
 For an interactive experience, launch `bash scripts/deployment_webui.sh` which provides
 a Gradio interface to select and run the included use cases.
 


### PR DESCRIPTION
## Summary
- create/activate `cosmos-predict1` conda environment in deploy script
- install requirements inside the conda env and patch TE linkage
- note conda usage in README

## Testing
- `python scripts/test_environment.py | head -n 10`

------
https://chatgpt.com/codex/tasks/task_e_686fd9cf8748832abf8fbf9d888b5a99